### PR TITLE
Fix sed issue

### DIFF
--- a/.github/workflows/JDCloud-AX6000-Baili.yml
+++ b/.github/workflows/JDCloud-AX6000-Baili.yml
@@ -156,7 +156,7 @@ jobs:
         \t\tlocal wifi1_mac=\"\$(macaddr_setbit_la \$wifi0_mac)\"
         \t\tsed -i \"/^MacAddress=.*/ {s/.*/MacAddress=\$wifi1_mac/;b;}; \\\$aMacAddress=\$wifi1_mac\" /etc/wireless/mediatek/mt7986-ax6000.dbdc.b1.dat" > temp_insert.txt
         ## 将文本内容写入02_network
-        sed -i '/mediatek_setup_macs()/,/\};/ {/jdcloud,re-cp-03)/ {n;n;n;r temp_insert.txt
+        sed -i '/mediatek_setup_macs()/,/exit/ {/jdcloud,re-cp-03)/ {n;n;n;r temp_insert.txt
         }}' target/linux/mediatek/mt7986/base-files/etc/board.d/02_network
         
     - name: 选择无线firmware


### PR DESCRIPTION
加菲猫大可以看看，原来的匹配定义`mediatek_setup_macs()`到`};`的行结束范围貌似不太对，还没到jdcloud就结束了，因为上一个ruijie的包含`};`，将文本内容写入02_network没生效。改成匹配到最后几行的`exit`就好了